### PR TITLE
TRG 317: Pull in latest changes from GDS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### New features
+
+You can now [configure your Tech Docs Template (TDT) to build your documentation site to use relative links to pages and assets](https://tdt-documentation.london.cloudapps.digital/configure_project/global_configuration/#build-your-site-using-relative-links).
+
+Thanks [@eddgrant](https://github.com/eddgrant) for contributing this feature and the associated fixes.
+
+This change was introduced in [pull request #291: Support sites deployed on paths other than "/" (by generating relative links)](https://github.com/alphagov/tech-docs-gem/pull/291). 
+
 ## 3.1.0
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-Deprecation warnings from Nokogiri addressed when rendering markdown tables
+- [#296: Fix Nokogiri Node.new deprecation warnings](https://github.com/alphagov/tech-docs-gem/pull/296) (thanks [@timja](https://github.com/timja))
 
 ## 3.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 3.2.0
+
 ### New features
 
 You can now [configure your Tech Docs Template (TDT) to build your documentation site to use relative links to pages and assets](https://tdt-documentation.london.cloudapps.digital/configure_project/global_configuration/#build-your-site-using-relative-links).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 3.2.1
+
 ### Fixes
 
 - [#296: Fix Nokogiri Node.new deprecation warnings](https://github.com/alphagov/tech-docs-gem/pull/296) (thanks [@timja](https://github.com/timja))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+Deprecation warnings from Nokogiri addressed when rendering markdown tables
+
 ## 3.2.0
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## 3.1.0
+
+### New features
+
+There are some steps you should follow as the Technical Documentation Template (TDT) now uses GOV.UK Frontend 4.0.0. 
+
+1. Update your documentation site to use the latest template version. You can [follow the TDT guidance on using the latest template version](https://tdt-documentation.london.cloudapps.digital/maintain_project/use_latest_template/).
+2. Check your documentation site displays correctly. If your site does not display correctly, you can refer to the [GOV.UK Frontend 4.0.0 release note](https://github.com/alphagov/govuk-frontend/releases/tag/v4.0.0) for more information. 
+
 ## 3.0.1
 
 ### Fixes

--- a/example/source/code.html.md
+++ b/example/source/code.html.md
@@ -10,32 +10,9 @@ A paragraph with a `code` element within it.
 
 An example of a table with a `code` element within it.
 
-<div class="table-container">
-  <table>
-    <thead>
-      <tr>
-        <th style="text-align:left">httpResult</th>
-        <th style="text-align:left">Message</th>
-        <th style="text-align:left">How to fix</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td style="text-align:left"><code>400</code></td>
-        <td style="text-align:left">
-          <code>[{</code>
-          <br />
-          <code>"error": "BadRequestError",</code>
-          <br />
-          <code>"message": "Can't send to this recipient using a team-only API key"</code>
-          <br />
-          <code>]}</code>
-        </td>
-        <td style="text-align:left">Use the correct type of API key</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
+| httpResult | Message | How to fix |
+| -          | -       | -          |
+| `400`      | `[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient using a team-only API key"`<br>`]}` | Use the correct type of API key |
 
 An example of a code block with a long line length
 

--- a/lib/assets/javascripts/_modules/collapsible-navigation.js
+++ b/lib/assets/javascripts/_modules/collapsible-navigation.js
@@ -57,25 +57,31 @@
       $toggleLabel.text(setOpen ? 'Collapse ' + $heading.text() : 'Expand ' + $heading.text())
     }
 
+    /**
+     * Returns an absolute pathname to $target by combining it with window.location.href
+     * @param $target The target whose pathname to return. This may be an anchor with an absolute or relative href.
+     * @returns {string} The absolute pathname of $target
+     */
+    function getAbsolutePath ($target) {
+      return new URL($target.attr('href'), window.location.href).pathname
+    }
+
     function openActiveHeading () {
       var $activeElement
       var currentPath = window.location.pathname
-      var isActiveTrail = '[href*="' + currentPath + '"]'
-      // Add an exception for the root page, as every href includes /
-      if (currentPath === '/') {
-        isActiveTrail = '[href="' + currentPath + window.location.hash + '"]'
-      }
       for (var i = $topLevelItems.length - 1; i >= 0; i--) {
         var $element = $($topLevelItems[i])
         var $heading = $element.find('> a')
         // Check if this item href matches
-        if ($heading.is(isActiveTrail)) {
+        if (getAbsolutePath($heading) === currentPath) {
           $activeElement = $element
           break
         }
         // Otherwise check the children
         var $children = $element.find('li > a')
-        var $matchingChildren = $children.filter(isActiveTrail)
+        var $matchingChildren = $children.filter(function (_) {
+          return getAbsolutePath($(this)) === currentPath
+        })
         if ($matchingChildren.length) {
           $activeElement = $element
           break

--- a/lib/assets/javascripts/_modules/in-page-navigation.js
+++ b/lib/assets/javascripts/_modules/in-page-navigation.js
@@ -70,13 +70,18 @@
     function highlightActiveItemInToc (fragment) {
       // Navigation items for single page navigation don't necessarily include the path name, but
       // navigation items for multipage navigation items do include it. This checks for either case.
-      var $activeTocItem = $tocItems.filter(
-        '[href="' + window.location.pathname + fragment + '"],[href="' + fragment + '"]'
-      )
+      var $activeTocItem = $tocItems.filter(function (_) {
+        var url = new URL($(this).attr('href'), window.location.href)
+        return url.href === window.location.href
+      })
+
       // Navigation items with children don't contain fragments in their url
       // Check to see if any nav items contain just the path name.
       if (!$activeTocItem.get(0)) {
-        $activeTocItem = $tocItems.filter('[href="' + window.location.pathname + '"]')
+        $activeTocItem = $tocItems.filter(function (_) {
+          var url = new URL($(this).attr('href'), window.location.href)
+          return url.hash === '' && url.pathname === window.location.pathname
+        })
       }
       if ($activeTocItem.get(0)) {
         $tocItems.removeClass('toc-link--in-view')

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -16,7 +16,7 @@
     var results
     var query
     var maxSearchEntries = 20
-    var searchIndexPath
+    var pathToSiteRoot
 
     this.start = function start ($element) {
       $searchForm = $element.find('form')
@@ -26,7 +26,7 @@
       $searchResults = $searchResultsWrapper.find('.search-results__content')
       $searchResultsTitle = $searchResultsWrapper.find('.search-results__title')
       $searchHelp = $('#search-help')
-      searchIndexPath = $element.data('searchIndexPath')
+      pathToSiteRoot = $element.data('pathToSiteRoot')
 
       changeSearchAction()
       changeSearchLabel()
@@ -40,7 +40,7 @@
           query = s.getQuery()
           if (query) {
             $searchInput.val(query)
-            doSearch(query)
+            doSearch(query, pathToSiteRoot)
             doAnalytics()
             document.title = query + ' - ' + document.title
           }
@@ -51,7 +51,7 @@
     this.downloadSearchIndex = function downloadSearchIndex () {
       updateTitle('Loading search results')
       $.ajax({
-        url: searchIndexPath,
+        url: pathToSiteRoot + 'search.json',
         cache: true,
         method: 'GET',
         success: function (data) {
@@ -67,7 +67,7 @@
       // We need JavaScript to do search, so if JS is not available the search
       // input sends the query string to Google. This JS function changes the
       // input to instead send it to the search page.
-      $searchForm.prop('action', '/search')
+      $searchForm.prop('action', pathToSiteRoot + 'search/index.html')
       $searchForm.find('input[name="as_sitesearch"]').remove()
     }
 
@@ -88,10 +88,10 @@
       return query
     }
 
-    function doSearch (query) {
+    function doSearch (query, pathToSiteRoot) {
       s.search(query, function (r) {
         results = r
-        renderResults(query)
+        renderResults(query, pathToSiteRoot)
         updateTitle()
       })
     }
@@ -140,7 +140,7 @@
       callback(getResults(query))
     }
 
-    function renderResults (query) {
+    function renderResults (query, pathToSiteRoot) {
       var output = ''
       if (results.length === 0) {
         output += '<p>Nothing found</p>'
@@ -151,7 +151,9 @@
         var content = s.processContent(result.content, query)
         output += '<li class="search-result">'
         output += '<h3 class="search-result__title">'
-        output += '<a href="' + result.url + '">'
+        var pagePathWithoutLeadingSlash = result.url.startsWith('/') ? result.url.slice(1) : result.url
+        var url = pathToSiteRoot.startsWith('.') ? pathToSiteRoot + pagePathWithoutLeadingSlash : '/' + pagePathWithoutLeadingSlash
+        output += '<a href="' + url + '">'
         output += result.title
         output += '</a>'
         output += '</h3>'

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -16,6 +16,7 @@
     var results
     var query
     var maxSearchEntries = 20
+    var searchIndexPath
 
     this.start = function start ($element) {
       $searchForm = $element.find('form')
@@ -25,6 +26,7 @@
       $searchResults = $searchResultsWrapper.find('.search-results__content')
       $searchResultsTitle = $searchResultsWrapper.find('.search-results__title')
       $searchHelp = $('#search-help')
+      searchIndexPath = $element.data('searchIndexPath')
 
       changeSearchAction()
       changeSearchLabel()
@@ -49,7 +51,7 @@
     this.downloadSearchIndex = function downloadSearchIndex () {
       updateTitle('Loading search results')
       $.ajax({
-        url: '/search.json',
+        url: searchIndexPath,
         cache: true,
         method: 'GET',
         success: function (data) {

--- a/lib/assets/stylesheets/_govuk_tech_docs.scss
+++ b/lib/assets/stylesheets/_govuk_tech_docs.scss
@@ -1,4 +1,4 @@
-$govuk-assets-path: "/assets/govuk/assets/";
+$govuk-assets-path: "/assets/govuk/assets/" !default;
 
 // Include only the bits of GOV.UK Frontend we need
 $govuk-new-link-styles: true;

--- a/lib/assets/stylesheets/modules/_anchored-heading.scss
+++ b/lib/assets/stylesheets/modules/_anchored-heading.scss
@@ -18,12 +18,12 @@
     text-decoration: none;
     text-indent: -9999em;
 
-    background-image: url('/images/anchored-heading-icon.png');
+    background-image: image-url('/images/anchored-heading-icon.png');
     background-repeat: no-repeat;
     background-position: center center;
 
     @include govuk-device-pixel-ratio {
-      background-image: url('/images/anchored-heading-icon-2x.png');
+      background-image: image-url('/images/anchored-heading-icon-2x.png');
       background-size: $icon-width $icon-height;
     }
 

--- a/lib/assets/stylesheets/modules/_search.scss
+++ b/lib/assets/stylesheets/modules/_search.scss
@@ -36,7 +36,7 @@ $input-size: 40px;
   padding: 0;
   width: $input-size;
   height: 100%;
-  background-image: url('/images/search-button.png');
+  background-image: image-url('/images/search-button.png');
   background-repeat: no-repeat;
   background-position: 2px 50%;
   text-indent: -5000px;
@@ -104,7 +104,7 @@ $input-size: 40px;
       left: -9px;
       width: 10px;
       height: 20px;
-      background: no-repeat url('/images/search-result-caret.svg') center right;
+      background: no-repeat image-url('/images/search-result-caret.svg') center right;
       background-size: contain;
     }
   }

--- a/lib/assets/stylesheets/modules/_toc.scss
+++ b/lib/assets/stylesheets/modules/_toc.scss
@@ -152,12 +152,12 @@
           height: 20px;
           float: right;
 
-          background-image: url('/images/govuk-icn-numbered-list.png');
+          background-image: image-url('/images/govuk-icn-numbered-list.png');
           background-repeat: no-repeat;
           background-position: left center;
 
           @include govuk-device-pixel-ratio {
-            background-image: url('/images/govuk-icn-numbered-list@2x.png');
+            background-image: image-url('/images/govuk-icn-numbered-list@2x.png');
             background-size: 20px 20px;
           }
         }
@@ -178,12 +178,12 @@
         height: 20px;
         cursor: pointer;
 
-        background-image: url('/images/govuk-icn-close.png');
+        background-image: image-url('/images/govuk-icn-close.png');
         background-repeat: no-repeat;
         background-position: left center;
 
         @include govuk-device-pixel-ratio {
-          background-image: url('/images/govuk-icn-close@2x.png');
+          background-image: image-url('/images/govuk-icn-close@2x.png');
           background-size: 20px 20px;
         }
 

--- a/lib/govuk_tech_docs.rb
+++ b/lib/govuk_tech_docs.rb
@@ -67,6 +67,7 @@ module GovukTechDocs
     context.activate :api_reference
 
     context.helpers do
+      include GovukTechDocs::PathHelpers
       include GovukTechDocs::TableOfContents::Helpers
       include GovukTechDocs::ContributionBanner
 

--- a/lib/govuk_tech_docs/pages.rb
+++ b/lib/govuk_tech_docs/pages.rb
@@ -1,10 +1,12 @@
 module GovukTechDocs
   class Pages
+    include GovukTechDocs::PathHelpers
     attr_reader :sitemap
 
-    def initialize(sitemap, config)
+    def initialize(sitemap, config, current_page)
       @sitemap = sitemap
       @config = config
+      @current_page = current_page
     end
 
     def to_json(*_args)
@@ -18,7 +20,7 @@ module GovukTechDocs
         review = PageReview.new(page, @config)
         {
           title: page.data.title,
-          url: "#{@config[:tech_docs][:host]}#{page.url}",
+          url: get_path_to_resource(@config, page, @current_page).to_s,
           review_by: review.review_by,
           owner_slack: review.owner_slack,
         }

--- a/lib/govuk_tech_docs/path_helpers.rb
+++ b/lib/govuk_tech_docs/path_helpers.rb
@@ -1,0 +1,30 @@
+module GovukTechDocs
+  module PathHelpers
+    def get_path_to_resource(config, resource, current_page)
+      if config[:relative_links]
+        resource_path_segments = resource.path.split("/").reject(&:empty?)[0..-2]
+        resource_file_name = resource.path.split("/")[-1]
+
+        path_to_site_root = path_to_site_root config, current_page.path
+        resource_path = path_to_site_root + resource_path_segments
+                                           .push(resource_file_name)
+                                           .join("/")
+      else
+        resource_path = resource.url
+      end
+      resource_path
+    end
+
+    def path_to_site_root(config, page_path)
+      if config[:relative_links]
+        number_of_ascents_to_site_root = page_path.to_s.split("/").reject(&:empty?)[0..-2].length
+        ascents = number_of_ascents_to_site_root.zero? ? ["."] : number_of_ascents_to_site_root.times.collect { ".." }
+        path_to_site_root = ascents.join("/").concat("/")
+      else
+        middleman_http_prefix = config[:http_prefix]
+        path_to_site_root = middleman_http_prefix.end_with?("/") ? middleman_http_prefix : "#{middleman_http_prefix}/"
+      end
+      path_to_site_root
+    end
+  end
+end

--- a/lib/govuk_tech_docs/tech_docs_html_renderer.rb
+++ b/lib/govuk_tech_docs/tech_docs_html_renderer.rb
@@ -69,7 +69,7 @@ module GovukTechDocs
         first_child.content = leading_text.sub(/# */, "")
       end
 
-      tr = Nokogiri::XML::Node.new "tr", fragment
+      tr = Nokogiri::XML::Node.new "tr", fragment.document
       tr.children = fragment.children
 
       tr.to_html
@@ -95,9 +95,9 @@ module GovukTechDocs
         # be `defined?`, so we can jump straight to rendering HTML ourselves.
 
         fragment = Nokogiri::HTML::DocumentFragment.parse("")
-        pre = Nokogiri::XML::Node.new "pre", fragment
+        pre = Nokogiri::XML::Node.new "pre", fragment.document
         pre["tabindex"] = "0"
-        code = Nokogiri::XML::Node.new "code", fragment
+        code = Nokogiri::XML::Node.new "code", fragment.document
         code["class"] = lang
         code.content = text
         pre.add_child code

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "3.0.1".freeze
+  VERSION = "3.1.0".freeze
 end

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "3.1.0".freeze
+  VERSION = "3.2.0".freeze
 end

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "3.2.0".freeze
+  VERSION = "3.2.1".freeze
 end

--- a/lib/source/api/pages.json.erb
+++ b/lib/source/api/pages.json.erb
@@ -1,1 +1,1 @@
-<%= GovukTechDocs::Pages.new(sitemap, config).to_json %>
+<%= GovukTechDocs::Pages.new(sitemap, config, current_page).to_json %>

--- a/lib/source/layouts/_search.erb
+++ b/lib/source/layouts/_search.erb
@@ -1,5 +1,5 @@
 <% if config[:tech_docs][:enable_search] %>
-<div class="search" data-module="search">
+<div class="search" data-module="search" data-search-index-path="<%= search_index_path %>">
   <form action="https://www.google.co.uk/search" method="get" role="search" class="search__form govuk-!-margin-bottom-4">
     <input type="hidden" name="as_sitesearch" value="<%= config[:tech_docs][:host] %>"/>
     <label class="govuk-label search__label" for="search" aria-hidden="true">

--- a/lib/source/layouts/_search.erb
+++ b/lib/source/layouts/_search.erb
@@ -1,5 +1,5 @@
 <% if config[:tech_docs][:enable_search] %>
-<div class="search" data-module="search" data-search-index-path="<%= search_index_path %>">
+<div class="search" data-module="search" data-path-to-site-root="<%= path_to_site_root config, current_page.path %>">
   <form action="https://www.google.co.uk/search" method="get" role="search" class="search__form govuk-!-margin-bottom-4">
     <input type="hidden" name="as_sitesearch" value="<%= config[:tech_docs][:host] %>"/>
     <label class="govuk-label search__label" for="search" aria-hidden="true">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1198,9 +1198,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mkdirp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,9 +71,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -1849,9 +1849,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true
         }
       }

--- a/spec/govuk_tech_docs/pages_spec.rb
+++ b/spec/govuk_tech_docs/pages_spec.rb
@@ -1,16 +1,32 @@
 RSpec.describe GovukTechDocs::Pages do
   describe "#to_json" do
-    it "returns the pages as JSON" do
+    it "returns the pages as JSON when using absolute links" do
+      current_page = double(path: "/api/pages.json")
       sitemap = double(resources: [
         double(url: "/a.html", data: double(title: "A thing", owner_slack: "#2ndline", last_reviewed_on: Date.yesterday, review_in: "0 days")),
         double(url: "/b.html", data: double(title: "B thing", owner_slack: "#2ndline", last_reviewed_on: Date.yesterday, review_in: "2 days")),
       ])
 
-      json = described_class.new(sitemap, tech_docs: {}).to_json
+      json = described_class.new(sitemap, {}, current_page).to_json
 
       expect(JSON.parse(json)).to eql([
         { "title" => "A thing", "url" => "/a.html", "review_by" => Date.yesterday.to_s, "owner_slack" => "#2ndline" },
         { "title" => "B thing", "url" => "/b.html", "review_by" => Date.tomorrow.to_s, "owner_slack" => "#2ndline" },
+      ])
+    end
+
+    it "returns the pages as JSON when using relative links" do
+      current_page = double(path: "/api/pages.json")
+      sitemap = double(resources: [
+        double(url: "/a.html", path: "/a.html", data: double(title: "A thing", owner_slack: "#2ndline", last_reviewed_on: Date.yesterday, review_in: "0 days")),
+        double(url: "/b/c.html", path: "/b/c.html", data: double(title: "B thing", owner_slack: "#2ndline", last_reviewed_on: Date.yesterday, review_in: "2 days")),
+      ])
+
+      json = described_class.new(sitemap, { relative_links: true }, current_page).to_json
+
+      expect(JSON.parse(json)).to eql([
+        { "title" => "A thing", "url" => "../a.html", "review_by" => Date.yesterday.to_s, "owner_slack" => "#2ndline" },
+        { "title" => "B thing", "url" => "../b/c.html", "review_by" => Date.tomorrow.to_s, "owner_slack" => "#2ndline" },
       ])
     end
   end

--- a/spec/govuk_tech_docs/path_helpers_spec.rb
+++ b/spec/govuk_tech_docs/path_helpers_spec.rb
@@ -1,0 +1,64 @@
+RSpec.describe GovukTechDocs::PathHelpers do
+  include GovukTechDocs::PathHelpers
+
+  describe "#get_path_to_resource" do
+    it "calculates the path to a resource when using absolute links" do
+      resource_url = "/documentation/introduction/index.html"
+
+      config = {}
+      resource = double("resource", url: resource_url)
+
+      resource_path = get_path_to_resource(config, resource, nil)
+      expect(resource_path).to eql(resource_url)
+    end
+
+    it "calculates the path to a resource when using relative links" do
+      current_page_path = "/documentation/introduction/section-one/index.html"
+      url = "/documentation/introduction/index.html"
+
+      config = {
+        relative_links: true,
+      }
+      resource = double("resource", url: url, path: url)
+      current_page = double("current_page", path: current_page_path)
+
+      resource_path = get_path_to_resource(config, resource, current_page)
+      expect(resource_path).to eql("../../../documentation/introduction/index.html")
+    end
+  end
+
+  describe "#path_to_site_root" do
+    it "calculates the path from a page to the site root when using absolute links" do
+      page_path = "/documentation/introduction/index.html"
+
+      config = {
+        http_prefix: "/", # This is Middleman's default setting.
+      }
+
+      path_to_site_root = path_to_site_root(config, page_path)
+      expect(path_to_site_root).to eql("/")
+    end
+
+    it "calculates the path from a page to the site root when a middleman http prefix" do
+      page_path = "/bananas/documentation/introduction/index.html"
+
+      config = {
+        http_prefix: "/bananas",
+      }
+
+      path_to_site_root = path_to_site_root(config, page_path)
+      expect(path_to_site_root).to eql("/bananas/")
+    end
+
+    it "calculates the path from a page to the site root when using relative links" do
+      page_path = "/documentation/introduction/index.html"
+
+      config = {
+        relative_links: true,
+      }
+
+      path_to_site_root = path_to_site_root(config, page_path)
+      expect(path_to_site_root).to eql("../../")
+    end
+  end
+end

--- a/spec/javascripts/search-spec.js
+++ b/spec/javascripts/search-spec.js
@@ -10,7 +10,7 @@ describe('Search', function () {
 
   beforeEach(function () {
     module = new GOVUK.Modules.Search()
-    $element = $('<div class="search" data-module="search">' +
+    $element = $('<div class="search" data-module="search" data-path-to-site-root="/">' +
   '<form action="https://www.google.co.uk/search" method="get" role="search">' +
     '<input type="hidden" name="as_sitesearch" value="<%= config[:tech_docs][:host] %>"/>' +
     '<label for="search"  class="govuk-label search__label">Search (via Google)</label>' +

--- a/spec/table_of_contents/helpers_spec.rb
+++ b/spec/table_of_contents/helpers_spec.rb
@@ -126,16 +126,20 @@ describe GovukTechDocs::TableOfContents::Helpers do
 
     subject { Subject.new }
 
-    it "builds a table of contents from several page resources" do
+    it "builds a table of contents using absolute links from several page resources" do
       resources = []
       resources[0] = FakeResource.new("/index.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 10, "Index");
-      resources[1] = FakeResource.new("/a.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 10, "Sub page A", resources[0]);
-      resources[2] = FakeResource.new("/b.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 20, "Sub page B", resources[0]);
-      resources[0].add_children [resources[1], resources[2]]
+      resources[1] = FakeResource.new("/1/2/a.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 20, "Sub page A", resources[0]);
+      resources[2] = FakeResource.new("/1/2/3/b.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 30, "Sub page A", resources[0]);
+      resources[3] = FakeResource.new("/1/2/3/4/c.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 40, "Sub page B", resources[0]);
+      resources[4] = FakeResource.new("/1/5/d.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 50, "Sub page A", resources[0]);
+      resources[5] = FakeResource.new("/1/5/6/e.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 60, "Sub page A", resources[0]);
+      resources[0].add_children [resources[1], resources[2], resources[3], resources[4], resources[5]]
 
       current_page = double("current_page",
                             data: double("page_frontmatter", description: "The description.", title: "The Title"),
-                            url: "/index.html",
+                            url: "/1/2/3/index.html",
+                            path: "/1/2/3/index.html",
                             metadata: { locals: {} })
 
       current_page_html = '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>';
@@ -152,18 +156,42 @@ describe GovukTechDocs::TableOfContents::Helpers do
 <li><a href="/index.html"><span>Index</span></a>
 <ul>
   <li>
-    <a href="/a.html"><span>Heading one</span></a>
+    <a href="/1/2/a.html"><span>Heading one</span></a>
     <ul>
       <li>
-        <a href="/a.html#heading-two"><span>Heading two</span></a>
+        <a href="/1/2/a.html#heading-two"><span>Heading two</span></a>
       </li>
     </ul>
   </li>
   <li>
-    <a href="/b.html"><span>Heading one</span></a>
+    <a href="/1/2/3/b.html"><span>Heading one</span></a>
     <ul>
       <li>
-        <a href="/b.html#heading-two"><span>Heading two</span></a>
+        <a href="/1/2/3/b.html#heading-two"><span>Heading two</span></a>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <a href="/1/2/3/4/c.html"><span>Heading one</span></a>
+    <ul>
+      <li>
+        <a href="/1/2/3/4/c.html#heading-two"><span>Heading two</span></a>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <a href="/1/5/d.html"><span>Heading one</span></a>
+    <ul>
+      <li>
+        <a href="/1/5/d.html#heading-two"><span>Heading two</span></a>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <a href="/1/5/6/e.html"><span>Heading one</span></a>
+    <ul>
+      <li>
+        <a href="/1/5/6/e.html#heading-two"><span>Heading two</span></a>
       </li>
     </ul>
   </li>
@@ -175,7 +203,85 @@ describe GovukTechDocs::TableOfContents::Helpers do
       expect(subject.multi_page_table_of_contents(resources, current_page, config, current_page_html).strip).to eq(expected_multi_page_table_of_contents.strip)
     end
 
-    it "builds a table of contents from several page resources with a custom http prefix ocnfigured" do
+    it "builds a table of contents using relative links from several page resources" do
+      resources = []
+      resources[0] = FakeResource.new("/index.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 10, "Index");
+      resources[1] = FakeResource.new("/1/2/a.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 20, "Sub page A", resources[0]);
+      resources[2] = FakeResource.new("/1/2/3/b.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 30, "Sub page A", resources[0]);
+      resources[3] = FakeResource.new("/1/2/3/4/c.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 40, "Sub page B", resources[0]);
+      resources[4] = FakeResource.new("/1/5/d.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 50, "Sub page A", resources[0]);
+      resources[5] = FakeResource.new("/1/5/6/e.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 60, "Sub page A", resources[0]);
+      resources[0].add_children [resources[1], resources[2], resources[3], resources[4], resources[5]]
+
+      current_page = double("current_page",
+                            data: double("page_frontmatter", description: "The description.", title: "The Title"),
+                            url: "/1/2/3/index.html",
+                            path: "/1/2/3/index.html",
+                            metadata: { locals: {} })
+
+      current_page_html = '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>';
+
+      config = {
+        http_prefix: "/",
+        relative_links: true,
+        tech_docs: {
+          max_toc_heading_level: 3,
+        },
+      }
+
+      expected_multi_page_table_of_contents = %{
+<ul>
+<li><a href="../../../index.html"><span>Index</span></a>
+<ul>
+  <li>
+    <a href="../../../1/2/a.html"><span>Heading one</span></a>
+    <ul>
+      <li>
+        <a href="../../../1/2/a.html#heading-two"><span>Heading two</span></a>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <a href="../../../1/2/3/b.html"><span>Heading one</span></a>
+    <ul>
+      <li>
+        <a href="../../../1/2/3/b.html#heading-two"><span>Heading two</span></a>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <a href="../../../1/2/3/4/c.html"><span>Heading one</span></a>
+    <ul>
+      <li>
+        <a href="../../../1/2/3/4/c.html#heading-two"><span>Heading two</span></a>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <a href="../../../1/5/d.html"><span>Heading one</span></a>
+    <ul>
+      <li>
+        <a href="../../../1/5/d.html#heading-two"><span>Heading two</span></a>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <a href="../../../1/5/6/e.html"><span>Heading one</span></a>
+    <ul>
+      <li>
+        <a href="../../../1/5/6/e.html#heading-two"><span>Heading two</span></a>
+      </li>
+    </ul>
+  </li>
+</ul>
+</li>
+</ul>
+      }
+
+      expect(subject.multi_page_table_of_contents(resources, current_page, config, current_page_html).strip).to eq(expected_multi_page_table_of_contents.strip)
+    end
+
+    it "builds a table of contents from several page resources with a custom http prefix configured" do
       resources = []
       resources[0] = FakeResource.new("/prefix/index.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 10, "Index");
       resources[1] = FakeResource.new("/prefix/a.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 10, "Sub page A", resources[0]);
@@ -185,6 +291,7 @@ describe GovukTechDocs::TableOfContents::Helpers do
       current_page = double("current_page",
                             data: double("page_frontmatter", description: "The description.", title: "The Title"),
                             url: "/prefix/index.html",
+                            path: "/prefix/index.html",
                             metadata: { locals: {} })
 
       current_page_html = '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>';
@@ -231,6 +338,7 @@ describe GovukTechDocs::TableOfContents::Helpers do
       current_page = double("current_page",
                             data: double("page_frontmatter", description: "The description.", title: "The Title"),
                             url: "/index.html",
+                            path: "/index.html",
                             metadata: { locals: {} })
 
       current_page_html = '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2><h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2><h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>';


### PR DESCRIPTION
- Update CHANGELOG.md
- Release v3.1.0
- Use search_index_path helper to locate Search assets
- Allow GOV UK assets path to be overriden
- Use helpers for asset URLs
- TRG-128 - Generate Table of Content links as relative links.
- TRG-128: Make search function work when using generating sites using relative links.
- TRG-128: Refactor path helpers out in to their own module.
- TRG-128: Make /api/pages.json endpoint return relative links when the sites is configured to use relative links.
- TRG-128: Make nav bar expanding, collapsing and highlighting work when using generating sites using relative links.
- Fix Rubocop linting errors.
- Remove TODO
- isOnSearchPage: Remove erroneous regular expression wildcard prefix.
- changeSearchAction(): Don't pass already in-scope variable to function.
- Replace use of const with var.
- Search: Add data-path-to-site-root attribute.
- Use :http_prefix when calculating the path to the site root, when using absolute links.
- TRG-128: Ensure http_prefix is not duplicated when generating search result links.
- TRG-128: Revert back to always obtaining search results from /search.json
- Update changelog
- Release v3.2.0
- Convert html table to markdown
- Pass a document rather than a fragment to new node
- Bump minimist from 1.2.5 to 1.2.6
- Update changelog
- Release v3.2.1
- Bump ansi-regex from 4.1.0 to 4.1.1
